### PR TITLE
Add issue templates aligned with new area taxonomy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: Report a defect or behavioral regression
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area(s)
+      description: Select the logical work area(s)
+      multiple: true
+      options:
+        - area:rf-pipeline
+        - area:protocol
+        - area:tsbk
+        - area:cli
+        - area:docs
+        - area:metadata-output
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is wrong?
+      placeholder: Briefly describe the issue.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction Steps
+      description: Exact steps and commands to reproduce.
+      placeholder: |
+        1. Run ...
+        2. Feed ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+    validations:
+      required: true
+
+  - type: input
+    id: command
+    attributes:
+      label: Command/Args Used
+      placeholder: p25 cc --device ... --sample-rate ...
+
+  - type: input
+    id: input_data
+    attributes:
+      label: Input Capture/Fixture
+      placeholder: samples/iq/...
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs/Output
+      render: shell
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions / Design Discussion
+    url: https://github.com/stevejost/trunker/discussions
+    about: Use discussions for open-ended design and architecture topics.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Propose a new capability or enhancement
+title: "[Feature] "
+labels:
+  - enhancement
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area(s)
+      description: Select the logical work area(s)
+      multiple: true
+      options:
+        - area:rf-pipeline
+        - area:protocol
+        - area:tsbk
+        - area:cli
+        - area:docs
+        - area:metadata-output
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What user/problem need does this address?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed Solution
+      description: Describe the design at a high level.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Optional alternatives or tradeoffs.
+

--- a/.github/ISSUE_TEMPLATE/technical_debt.yml
+++ b/.github/ISSUE_TEMPLATE/technical_debt.yml
@@ -1,0 +1,66 @@
+name: Technical debt
+description: Refactor, hardening, architecture cleanup, or quality debt
+title: "[Debt] "
+labels:
+  - enhancement
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area(s)
+      description: Select the logical work area(s)
+      multiple: true
+      options:
+        - area:rf-pipeline
+        - area:protocol
+        - area:tsbk
+        - area:cli
+        - area:docs
+        - area:metadata-output
+    validations:
+      required: true
+
+  - type: dropdown
+    id: debt_type
+    attributes:
+      label: Debt Type
+      options:
+        - type:correctness
+        - Performance
+        - Test coverage
+        - Developer experience
+        - Documentation quality
+    validations:
+      required: true
+
+  - type: textarea
+    id: debt
+    attributes:
+      label: Debt Description
+    validations:
+      required: true
+
+  - type: textarea
+    id: risk
+    attributes:
+      label: Risk If Not Addressed
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Proposed Scope
+      description: Keep scope concrete and bounded.
+    validations:
+      required: true
+
+  - type: textarea
+    id: test_plan
+    attributes:
+      label: Test Plan
+      placeholder: |
+        - Unit tests:
+        - Integration tests:
+        - Real-capture verification:
+


### PR DESCRIPTION
## Summary
- add GitHub issue form templates for bug reports, feature requests, and technical debt
- add shared area selection fields aligned to current workstreams (`area:*` labels)
- disable blank issues and route open-ended design discussion to Discussions

## Why
- keeps issue intake consistent with the new area segmentation (`cli`, `rf pipeline`, `protocol`, etc.)
- improves triage and filtering as the project grows

## Notes
- existing issues #1-#5 have already been labeled with the new taxonomy