### PR TITLE
LiveKit reconnection: pause publishers during hiccups

### DIFF
--- a/crates/p25-server/src/bridge.rs
+++ b/crates/p25-server/src/bridge.rs
@@ -7,6 +7,21 @@
 use tokio::sync::broadcast;
 use trunker::decode::event::{DecoderEvent, EventSink};
 
+/// LiveKit connection state, broadcast to publishers via a watch channel.
+///
+/// The room event handler sends updates through a [`tokio::sync::watch`]
+/// channel, and publishers check it to pause during hiccups and clean up
+/// stale track handles on reconnection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConnectionState {
+    /// Connected and operational.
+    Connected,
+    /// Connection lost, attempting to reconnect.
+    Reconnecting,
+    /// Permanently disconnected — publishers should shut down.
+    Disconnected,
+}
+
 /// Wrapper around [`DecoderEvent`] that is `Clone` for broadcast.
 ///
 /// `DecoderEvent` contains types that are not all `Clone`, so we

--- a/crates/p25-server/src/data_publisher.rs
+++ b/crates/p25-server/src/data_publisher.rs
@@ -13,10 +13,10 @@ use std::sync::Arc;
 
 use livekit::prelude::*;
 use serde::Serialize;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, watch};
 use tokio::time::{Duration, Instant};
 
-use crate::bridge::BroadcastEvent;
+use crate::bridge::{BroadcastEvent, ConnectionState};
 
 /// How long after the last audio frame before we consider a call ended.
 const CALL_TIMEOUT: Duration = Duration::from_secs(2);
@@ -75,7 +75,11 @@ impl DataPublisher {
         Self { room }
     }
 
-    pub async fn run(&self, mut rx: broadcast::Receiver<BroadcastEvent>) {
+    pub async fn run(
+        &self,
+        mut rx: broadcast::Receiver<BroadcastEvent>,
+        mut conn_state: watch::Receiver<ConnectionState>,
+    ) {
         // Talkgroups with an active call (have received audio recently).
         let mut active: HashMap<u16, CallState> = HashMap::new();
         let mut sweep_timer = tokio::time::interval(SWEEP_INTERVAL);
@@ -84,7 +88,11 @@ impl DataPublisher {
             tokio::select! {
                 result = rx.recv() => {
                     match result {
-                        Ok(event) => self.handle_event(event, &mut active).await,
+                        Ok(event) => {
+                            if *conn_state.borrow() == ConnectionState::Connected {
+                                self.handle_event(event, &mut active).await;
+                            }
+                        }
                         Err(broadcast::error::RecvError::Lagged(n)) => {
                             tracing::warn!(skipped = n, "data publisher lagged behind");
                         }
@@ -95,7 +103,26 @@ impl DataPublisher {
                     }
                 }
                 _ = sweep_timer.tick() => {
-                    self.sweep_expired(&mut active).await;
+                    if *conn_state.borrow() == ConnectionState::Connected {
+                        self.sweep_expired(&mut active).await;
+                    }
+                }
+                Ok(()) = conn_state.changed() => {
+                    match *conn_state.borrow_and_update() {
+                        ConnectionState::Reconnecting => {
+                            active.clear();
+                            tracing::warn!("connection lost, pausing data publisher");
+                        }
+                        ConnectionState::Connected => {
+                            tracing::info!("connection restored, resuming data publisher");
+                        }
+                        ConnectionState::Disconnected => {
+                            tracing::info!(
+                                "permanently disconnected, data publisher shutting down"
+                            );
+                            break;
+                        }
+                    }
                 }
             }
         }

--- a/crates/p25-server/src/livekit_publisher.rs
+++ b/crates/p25-server/src/livekit_publisher.rs
@@ -14,10 +14,10 @@ use livekit::prelude::*;
 use livekit::webrtc::audio_frame::AudioFrame;
 use livekit::webrtc::audio_source::AudioSourceOptions;
 use livekit::webrtc::audio_source::native::NativeAudioSource;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, watch};
 use tokio::time::{Duration, Instant};
 
-use crate::bridge::BroadcastEvent;
+use crate::bridge::{BroadcastEvent, ConnectionState};
 
 /// Sample rate for the IMBE vocoder output.
 ///
@@ -37,9 +37,6 @@ fn soft_limit(sample: f32) -> i16 {
     (32767.0_f32 * (sample / 32767.0_f32).tanh()) as i16
 }
 
-/// Duration of one IMBE voice frame (160 samples at 8 kHz).
-const FRAME_DURATION: Duration = Duration::from_millis(20);
-
 /// Mute a track after this much silence to stop RTP transmission.
 const MUTE_IDLE_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -52,8 +49,6 @@ struct TalkgroupTrack {
     source: NativeAudioSource,
     /// The published track handle, used for mute/unmute control.
     publication: LocalTrackPublication,
-    /// Earliest time the next frame should be sent (real-time pacing).
-    next_send: Instant,
     /// When the last audio frame was received (for idle muting).
     last_audio: Instant,
     /// Whether the track is currently muted (no RTP transmission).
@@ -85,8 +80,13 @@ impl AudioPublisher {
 
     /// Run the publisher loop, consuming events from the broadcast channel.
     ///
-    /// Blocks until the broadcast channel is closed or a fatal error occurs.
-    pub async fn run(&mut self, mut rx: broadcast::Receiver<BroadcastEvent>) -> anyhow::Result<()> {
+    /// Blocks until the broadcast channel is closed, the connection is
+    /// permanently lost, or a fatal error occurs.
+    pub async fn run(
+        &mut self,
+        mut rx: broadcast::Receiver<BroadcastEvent>,
+        mut conn_state: watch::Receiver<ConnectionState>,
+    ) -> anyhow::Result<()> {
         let mut mute_sweep = tokio::time::interval(MUTE_SWEEP_INTERVAL);
         mute_sweep.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -97,6 +97,10 @@ impl AudioPublisher {
                         Ok(BroadcastEvent::Audio {
                             talkgroup, samples, ..
                         }) => {
+                            // Drop frames while disconnected — tracks are stale.
+                            if *conn_state.borrow() != ConnectionState::Connected {
+                                continue;
+                            }
                             if let Err(e) = self.publish_audio(talkgroup, &samples).await {
                                 tracing::warn!(
                                     talkgroup,
@@ -118,7 +122,28 @@ impl AudioPublisher {
                     }
                 }
                 _ = mute_sweep.tick() => {
-                    self.mute_idle_tracks();
+                    if *conn_state.borrow() == ConnectionState::Connected {
+                        self.mute_idle_tracks();
+                    }
+                }
+                Ok(()) = conn_state.changed() => {
+                    match *conn_state.borrow_and_update() {
+                        ConnectionState::Reconnecting => {
+                            let count = self.tracks.len();
+                            self.tracks.clear();
+                            tracing::warn!(
+                                tracks_cleared = count,
+                                "connection lost, cleared stale tracks"
+                            );
+                        }
+                        ConnectionState::Connected => {
+                            tracing::info!("connection restored, tracks will re-publish on demand");
+                        }
+                        ConnectionState::Disconnected => {
+                            tracing::info!("permanently disconnected, audio publisher shutting down");
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -130,6 +155,11 @@ impl AudioPublisher {
     /// Applies gain, converts f32 vocoder samples to i16, and feeds the
     /// native 8 kHz samples directly to LiveKit. WebRTC's internal
     /// sinc resampler handles upsampling to 48 kHz before Opus encoding.
+    ///
+    /// No pacing sleep — the [`NativeAudioSource`] has a 1-second internal
+    /// buffer and WebRTC drains it at real-time rate. The decoder produces
+    /// frames at roughly real-time from the live SDR stream, so bursts are
+    /// absorbed by the buffer without blocking the event loop.
     async fn publish_audio(&mut self, talkgroup: u16, samples: &[f32]) -> anyhow::Result<()> {
         let gain = self.gain;
         let track = self.get_or_create_track(talkgroup).await?;
@@ -145,13 +175,6 @@ impl AudioPublisher {
         // Log peak level for debugging.
         let peak = samples.iter().copied().map(f32::abs).fold(0.0f32, f32::max);
         tracing::debug!(talkgroup, peak, "audio frame");
-
-        // Pace frames at real-time to prevent buffer overrun.
-        let now = Instant::now();
-        if now < track.next_send {
-            tokio::time::sleep_until(track.next_send).await;
-        }
-        track.next_send = Instant::now() + FRAME_DURATION;
 
         // Apply gain and soft-limit to i16. No upsampling -- WebRTC
         // resamples internally with a proper sinc filter.
@@ -227,7 +250,6 @@ impl AudioPublisher {
                 TalkgroupTrack {
                     source,
                     publication,
-                    next_send: Instant::now(),
                     last_audio: Instant::now(),
                     muted: false,
                 },

--- a/crates/p25-server/src/main.rs
+++ b/crates/p25-server/src/main.rs
@@ -36,7 +36,7 @@ fn parse_hex_u32(s: &str) -> Result<u32, String> {
     }
 }
 
-use bridge::BroadcastSink;
+use bridge::{BroadcastSink, ConnectionState};
 use data_publisher::DataPublisher;
 use livekit_publisher::AudioPublisher;
 use trunker::p25::nid::NidIntegrityPolicy;
@@ -482,38 +482,47 @@ async fn main() -> Result<()> {
     let audio_rx = sink.subscribe();
     let data_rx = sink.subscribe();
 
+    // Connection state watch channel: room event handler sends updates,
+    // publishers pause/resume based on state.
+    let (conn_tx, conn_rx) = tokio::sync::watch::channel(ConnectionState::Connected);
+
     // Spawn LiveKit audio publisher.
     let publisher_room = Arc::clone(&room);
     let audio_gain = cli.audio_gain;
     let audio_bitrate = cli.audio_bitrate;
+    let audio_conn_rx = conn_rx.clone();
     let audio_handle = tokio::spawn(async move {
         let mut publisher = AudioPublisher::new(publisher_room, audio_gain, audio_bitrate);
-        if let Err(e) = publisher.run(audio_rx).await {
+        if let Err(e) = publisher.run(audio_rx, audio_conn_rx).await {
             tracing::error!(error = %e, "audio publisher error");
         }
     });
 
     // Spawn LiveKit data channel publisher.
     let data_room = Arc::clone(&room);
+    let data_conn_rx = conn_rx.clone();
     let data_handle = tokio::spawn(async move {
         let publisher = DataPublisher::new(data_room);
-        publisher.run(data_rx).await;
+        publisher.run(data_rx, data_conn_rx).await;
     });
 
-    // Spawn room event handler: log connection state changes and signal
-    // shutdown on permanent disconnect.
+    // Spawn room event handler: broadcast connection state changes to
+    // publishers and signal shutdown on permanent disconnect.
     let room_running = running.clone();
     tokio::spawn(async move {
         while let Some(event) = room_events.recv().await {
             match event {
                 RoomEvent::Reconnecting => {
                     tracing::warn!("LiveKit connection lost, reconnecting...");
+                    let _ = conn_tx.send(ConnectionState::Reconnecting);
                 }
                 RoomEvent::Reconnected => {
                     tracing::info!("LiveKit reconnected");
+                    let _ = conn_tx.send(ConnectionState::Connected);
                 }
                 RoomEvent::Disconnected { reason } => {
                     tracing::error!(?reason, "LiveKit disconnected, shutting down");
+                    let _ = conn_tx.send(ConnectionState::Disconnected);
                     room_running.store(false, Ordering::Relaxed);
                     break;
                 }


### PR DESCRIPTION
## Summary
- Add `ConnectionState` watch channel so the room event handler broadcasts connection state to audio and data publishers
- During reconnection, publishers pause (drop frames, clear stale track handles) instead of writing to dead WebRTC handles
- On permanent disconnect, publishers shut down gracefully via the watch channel
- Remove per-frame pacing sleep from `AudioPublisher` — `NativeAudioSource` has a 1-second internal buffer and WebRTC drains at real-time rate, so the sleep was unnecessary and blocked the event loop

## Test plan
- [x] All 909 tests pass
- [ ] Verify reconnection behavior by temporarily disrupting network during a live session
- [ ] Confirm audio resumes cleanly after reconnection (tracks re-publish on demand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)